### PR TITLE
Fix 'choices' argument to correctly accept tuple

### DIFF
--- a/wtforms_appengine/ndb.py
+++ b/wtforms_appengine/ndb.py
@@ -166,7 +166,6 @@ class ModelConverterBase(object):
 
         if kwargs.get('choices', None):
             # Use choices in a select field.
-            kwargs['choices'] = [(v, v) for v in kwargs.get('choices')]
             return f.SelectField(**kwargs)
 
         if prop._choices:


### PR DESCRIPTION
Currently if you will pass `choices` argument for select field with list of tuples (as per docs) it will force to use only `value`, without label.