### PR TITLE
Supports KeyProperties with kind='StringModelName' params

### DIFF
--- a/tests/second_ndb_module.py
+++ b/tests/second_ndb_module.py
@@ -1,0 +1,4 @@
+from google.appengine.ext import ndb
+
+class SecondBook(ndb.Model):
+    author = ndb.KeyProperty(kind='Author')

--- a/tests/test_ndb.py
+++ b/tests/test_ndb.py
@@ -10,6 +10,7 @@ from wtforms.compat import text_type
 from wtforms_appengine.fields import KeyPropertyField
 from wtforms_appengine.ndb import model_form
 
+import second_ndb_module
 
 class Author(ndb.Model):
     name = ndb.StringProperty(required=True)
@@ -23,6 +24,7 @@ class Book(ndb.Model):
 
 
 class TestKeyPropertyField(TestCase):
+    nosegae_datastore_v3 = True
     class F(Form):
         author = KeyPropertyField(reference_class=Author)
 
@@ -61,6 +63,7 @@ class TestKeyPropertyField(TestCase):
 
 
 class TestModelForm(TestCase):
+    nosegae_datastore_v3 = True
     EXPECTED_AUTHOR = [('name', TextField), ('city', TextField), ('age', IntegerField), ('is_admin', BooleanField)]
 
     def test_author(self):
@@ -73,6 +76,16 @@ class TestModelForm(TestCase):
         authors = set(text_type(x.key.id()) for x in fill_authors(Author))
         authors.add('__None')
         form = model_form(Book)
+        keys = set()
+        for key, b, c in form().author.iter_choices():
+            keys.add(key)
+
+        self.assertEqual(authors, keys)
+
+    def test_second_book(self):
+        authors = set(text_type(x.key.id()) for x in fill_authors(Author))
+        authors.add('__None')
+        form = model_form(second_ndb_module.SecondBook)
         keys = set()
         for key, b, c in form().author.iter_choices():
             keys.add(key)

--- a/wtforms_appengine/ndb.py
+++ b/wtforms_appengine/ndb.py
@@ -335,9 +335,12 @@ class ModelConverter(ModelConverterBase):
                 reference_class = prop._reference_class
 
             if isinstance(reference_class, string_types):
-                # reference class is a string, try to retrieve the model object.
-                mod = __import__(model.__module__, None, None, [reference_class], 0)
-                reference_class = getattr(mod, reference_class)
+                # This assumes that the referenced module is already imported.
+                try:
+                    reference_class = model._kind_map[reference_class]
+                except KeyError:
+                    # If it's not imported, just bail, as we can't edit this field safely.
+                    return None
             kwargs['reference_class'] = reference_class
         kwargs.setdefault('allow_blank', not prop._required)
         return KeyPropertyField(**kwargs)


### PR DESCRIPTION
This assumes the relevant models have already been imported, but at least no longer needs to assume all models were in the same module