### PR TITLE
Fix _KeyClassProperty bug

### DIFF
--- a/wtforms_appengine/ndb.py
+++ b/wtforms_appengine/ndb.py
@@ -236,6 +236,8 @@ class ModelConverter(ModelConverterBase):
     | GenericProperty    | None              | generic      | always skipped   |
     +--------------------+-------------------+--------------+------------------+
     | ComputedProperty   | none              |              | always skipped   |
+    +--------------------+-------------------+--------------+------------------+
+    | _ClassKeyProperty  | none              |              | always skipped   |
     +====================+===================+==============+==================+
 
     """  # noqa
@@ -358,6 +360,9 @@ class ModelConverter(ModelConverterBase):
         else:
             return KeyPropertyField(**kwargs)
 
+    def convert__ClassKeyProperty(self, model, prop, kwargs):
+            """Returns a form field for a ``ndb.ComputedProperty``."""
+            return None
 
 def model_fields(model, only=None, exclude=None, field_args=None,
                  converter=None):


### PR DESCRIPTION
EDITED: Removed the version number bump from pull request. This pull request now only covers a bug where classes inherited from PolyModel had their class attributes skipped.

~~There have been fixes applied to wtforms-appengine since its 0.1 flag. Unfortunately, if you pip install the latest, it just goes out and looks for 0.1 and finds an old package. (Try it. do a pip install WTForms-Appengine and see what code you get; it's broken!)~~

~~So please, bump the version number and release on PyPi.~~